### PR TITLE
provide compatibility with newer versions of symfony

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
         </service>
 
         <service id="swiftmailer.spool.db" alias="white_october.swiftmailer_db.spool" />
+        <service id="swiftmailer.mailer.default.spool.db" alias="white_october.swiftmailer_db.spool" />
     </services>
 
 </container>


### PR DESCRIPTION
Due to new configurations it needs to provide default custom spool service too. (update for symfony 2.3.3)
