### PR TITLE
Add option to keep sent messages in the database

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode("entity_class")->isRequired()->end()
+                ->scalarNode("keep_sent_messages")->defaultFalse()->end()
             ->end()
         ;
 

--- a/DependencyInjection/WhiteOctoberSwiftMailerDBExtension.php
+++ b/DependencyInjection/WhiteOctoberSwiftMailerDBExtension.php
@@ -39,6 +39,7 @@ class WhiteOctoberSwiftMailerDBExtension extends Extension
         $config = $processor->processConfiguration($configuration, $configs);
 
         $container->setParameter("white_october.swiftmailer_db.spool.entity_class", $config["entity_class"]);
+        $container->setParameter("white_october.swiftmailer_db.spool.keep_sent_messages", $config["keep_sent_messages"]);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ and add some configuration parameters, so that it knows which entity you want to
 
 That's it for bundle installation and configuration.
 
+
+
 Mail entity
 ===========
 
@@ -81,3 +83,12 @@ Once you have your entity all set up, use the full namespaced path in your `conf
 configuration as detailed above.
 
 
+
+Optional: keeping sent messages in the database
+===============================================
+
+By default, messages which were succesfully sent will be deleted from the database. It is possible to configure
+the bundle to keep those messages in your config.yml:
+
+    white_october_swift_mailer_db:
+        keep_sent_messages: true

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <service id="white_october.swiftmailer_db.spool" class="%white_october.swiftmailer_db.spool.class%">
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument>%white_october.swiftmailer_db.spool.entity_class%</argument>
+            <argument>%white_october.swiftmailer_db.spool.keep_sent_messages%</argument>
         </service>
 
         <service id="swiftmailer.spool.db" alias="white_october.swiftmailer_db.spool" />


### PR DESCRIPTION
This commit adds an option to keep sent e-mails in the database. I wanted to add a Command to clean up old messages too, but I was not sure how to make that database-agnostic. May be better to leave that to the user - they can add a task to their Bundle where they defined their mail entity and handle the cleanup any way they like.
