### PR TITLE
Make queue flushing work with deferred explicit change tracking policy

### DIFF
--- a/Spool/DatabaseSpool.php
+++ b/Spool/DatabaseSpool.php
@@ -128,12 +128,14 @@ class DatabaseSpool extends \Swift_ConfigurableSpool
         $time = time();
         foreach ($emails as $email) {
             $email->setStatus(EmailInterface::STATUS_PROCESSING);
+            $this->em->persist($email);
             $this->em->flush();
 
             $message = unserialize($email->getMessage());
             $count += $transport->send($message, $failedRecipients);
             if ($this->keepSentMessages === true) {
                 $email->setStatus(EmailInterface::STATUS_COMPLETE);
+                $this->em->persist($email);
             } else {
                 $this->em->remove($email);
             }


### PR DESCRIPTION
Persist entity before flush so the change gets saved even when deferred explicit tracking policy policy in use.
