### PR TITLE
start transport only if there is an email to send

### DIFF
--- a/Spool/DatabaseSpool.php
+++ b/Spool/DatabaseSpool.php
@@ -108,11 +108,6 @@ class DatabaseSpool extends \Swift_ConfigurableSpool
      */
     public function flushQueue(\Swift_Transport $transport, &$failedRecipients = null)
     {
-        if (!$transport->isStarted())
-        {
-            $transport->start();
-        }
-
         $repoClass = $this->getManager()->getRepository($this->entityClass);
         $limit = $this->getMessageLimit();
         $limit = $limit > 0 ? $limit : null;
@@ -123,6 +118,11 @@ class DatabaseSpool extends \Swift_ConfigurableSpool
         );
         if (!count($emails)) {
             return 0;
+        }
+
+        if (!$transport->isStarted())
+        {
+            $transport->start();
         }
 
         $failedRecipients = (array) $failedRecipients;


### PR DESCRIPTION
Transports like the Swift_Transport_AbstractSmtpTransport start the connexion
during the start method.

So when running the swiftmailer:spool:send command the connexion is made to the
SMTP even if there no mail to send.

In order to avoid that the start method is called only after getting the list
of mail to send.

Swift_Transport_AbstractSmtpTransport